### PR TITLE
Fixing the "context deadline exceeded" issue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as builder
+FROM golang:bullseye as builder
 ADD . /src
 RUN cd /src && make linux_amd64
 

--- a/servicenow-instance-wakeup.go
+++ b/servicenow-instance-wakeup.go
@@ -49,11 +49,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	opts := []chromedp.ExecAllocatorOption{
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
 		chromedp.DisableGPU,
-	}
+	)
 
 	log.Printf("Starting the app with debug=%t/headless=%t/account=%s", configuration.Debug, configuration.ChromeHeadless, configuration.Username)
 


### PR DESCRIPTION
This pull request addresses the "context deadline exceeded" issue that was occurring during the last step of the process. The issue could not be consistently reproduced, but I've included relevant logs to provide context.
The "context deadline exceeded" error was occurring intermittently during the last step of the process, causing the process to fail unpredictably.

Last leg of the logs:
```
2023/09/12 22:00:29 <- {"method":"Inspector.targetCrashed","params":{},"sessionId":"60C44BA185A07A201B26B4C4E0F6B7D4"}
2023/09/12 22:00:29 <- {"method":"Target.targetCrashed","params":{"targetId":"BBEA06D5C1B3F692E360CD296EB53F39","status":"crashed","errorCode":133}}
2023/09/12 22:00:29 <- {"method":"Target.targetCrashed","params":{"targetId":"BBEA06D5C1B3F692E360CD296EB53F39","status":"crashed","errorCode":133},"sessionId":"60C44BA185A07A201B26B4C4E0F6B7D4"}
could not find start building button: context deadline exceeded
```

I've identified a similar issue and solution from chromedp/chromedp#1170 and applied it. And now it seems to work fine! (I could only test it once, but I can try testing it multiple times and observing if it works every single time)
edit: I've been testing it for some days now and it has worked every single time 😉 

Additional Notes:
I had to modify the Makefile so that I could build it locally in my machine (added the CGO_ENABLED=0 flag to the go build command).